### PR TITLE
Fixing RuntimeError simple_dqn_torch_2020.py

### DIFF
--- a/ReinforcementLearning/DeepQLearning/simple_dqn_torch_2020.py
+++ b/ReinforcementLearning/DeepQLearning/simple_dqn_torch_2020.py
@@ -66,7 +66,7 @@ class Agent():
 
     def choose_action(self, observation):
         if np.random.random() > self.epsilon:
-            state = T.tensor([observation]).to(self.Q_eval.device)
+            state = T.tensor([observation]).float().to(self.Q_eval.device)
             actions = self.Q_eval.forward(state)
             action = T.argmax(actions).item()
         else:


### PR DESCRIPTION
On my (windows 10, Cuda 11) platform i get an error and found this fix. Here is the error : 
Traceback (most recent call last):
  File "C:/Users/kerde/Documents/python/qlearning/main.py", line 133, in <module>
    action = agent.choose_action(observation)
  File "C:/Users/kerde/Documents/python/qlearning/main.py", line 84, in choose_action
    actions = self.Q_eval.forward(state)
  File "C:/Users/kerde/Documents/python/qlearning/main.py", line 40, in forward
    x = F.relu(self.fc1(state))
  File "C:\Users\kerde\miniconda3\envs\qlearning\lib\site-packages\torch\nn\modules\module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "C:\Users\kerde\miniconda3\envs\qlearning\lib\site-packages\torch\nn\modules\linear.py", line 93, in forward
    return F.linear(input, self.weight, self.bias)
  File "C:\Users\kerde\miniconda3\envs\qlearning\lib\site-packages\torch\nn\functional.py", line 1690, in linear
    ret = torch.addmm(bias, input, weight.t())
RuntimeError: expected scalar type Float but found Double