### PR TITLE
Remove obsolete params for SAC Agent constructor

### DIFF
--- a/ReinforcementLearning/PolicyGradient/SAC/sac_torch.py
+++ b/ReinforcementLearning/PolicyGradient/SAC/sac_torch.py
@@ -8,7 +8,7 @@ from networks import ActorNetwork, CriticNetwork, ValueNetwork
 class Agent():
     def __init__(self, alpha=0.0003, beta=0.0003, input_dims=[8],
             env=None, gamma=0.99, n_actions=2, max_size=1000000, tau=0.005,
-            layer1_size=256, layer2_size=256, batch_size=256, reward_scale=2):
+            batch_size=256, reward_scale=2):
         self.gamma = gamma
         self.tau = tau
         self.memory = ReplayBuffer(max_size, input_dims, n_actions)


### PR DESCRIPTION
Remove the two params from constructor layer1_size=256, layer2_size=256 
since not used in any part of the code.